### PR TITLE
Go build updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/hawkthorne/tmx2lua
+
+go 1.22.5
+
+require github.com/kyleconroy/go-tmx v0.0.0-20120904024524-5c56c9e46dd9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kyleconroy/go-tmx v0.0.0-20120904024524-5c56c9e46dd9 h1:WkUPiFrPlbc4vWq3Pq2BReHK0CtaUZiwHk5eA3NEWfA=
+github.com/kyleconroy/go-tmx v0.0.0-20120904024524-5c56c9e46dd9/go.mod h1:T2uTBvMMp0SubY/8wdcoiiyx5FwdjZBcraid+gnVJe4=


### PR DESCRIPTION
This is probably a poor way to address this problem, but I found downloading the v1.0.0 osx binary not to work on Apple Silicon.

To address this I've added a `go.mod` and `go.sum` file to make building with the latest go easier and will publish a new release under v.1.0.1